### PR TITLE
Nixify a development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+
+source_env_if_exists .envrc.local

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1636678824,
+        "narHash": "sha256-NDB9CenPn5z2xbmG/X+Mg6Jd8iUEf7dfprQfXxSD6X8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bf346b557b76ffce74167f37752656dede5957f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "fsdiff development environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    (flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ]
+      (system: nixpkgs.lib.fix (flake:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
+          packages = rec {
+            go = pkgs.go;
+            git = pkgs.git;
+          };
+
+          devShell = pkgs.mkShell {
+            packages = builtins.attrValues self.packages.${system};
+            shellHook = ''
+              GOROOT=${pkgs.go}/share/go
+            '';
+          };
+        }
+      )));
+}


### PR DESCRIPTION
So that we're all using the same go version and we can add any other deps if we need to! Building the project still works through make but the dev env can come from direnv and a nix flake.