### PR TITLE
Switch to godirwalk for a bit better performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gadget-inc/fsdiff
 go 1.16
 
 require (
+	github.com/karrick/godirwalk v1.16.1
 	github.com/klauspost/compress v1.13.6
 	github.com/minio/sha256-simd v1.0.0
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=


### PR DESCRIPTION
 - It doesn't throw errors when trying to stat files that have just been removed
 - It saves us one syscall per ignored file
 - It is more memory efficient

Don't see why not!

On my machine on `main`:

```
cd test && go test -bench=. -benchtime=10x
goos: darwin
goarch: amd64
pkg: github.com/gadget-inc/fsdiff/test
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkSimpleInitialDiff-12    	      10	    413688 ns/op
BenchmarkReactInitialDiff-12     	      10	2493167343 ns/op
BenchmarkReactChangedDiff-12     	      10	3578962576 ns/op
```

on this branch:

```
goos: darwin
goarch: amd64
pkg: github.com/gadget-inc/fsdiff/test
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkSimpleInitialDiff-12    	      10	    742025 ns/op
BenchmarkReactInitialDiff-12     	      10	2632499614 ns/op
BenchmarkReactChangedDiff-12     	      10	3750612520 ns/op
PASS
```

Doesn't really seem much faster but isn't slower and saves us one more error condition so I think it's still worth it.